### PR TITLE
Fix ng-options expression by using `track by`.

### DIFF
--- a/vixen/html/vixen_ui.html
+++ b/vixen/html/vixen_ui.html
@@ -43,11 +43,11 @@
 
     <label>Grid</label>
     <select ng-model="vixen.grid"
-        ng-options="g for g in vixen.available_grids">
+        ng-options="g for g in vixen.available_grids track by g">
     </select>
     <label>Camera:</label>
     <select ng-model="vixen.camera"
-        ng-options="c for c in vixen.available_cameras">
+        ng-options="c for c in vixen.available_cameras track by c">
     </select>
 
     <div style="height:150px; width: 400px; overflow:scroll;" class="resizable">


### PR DESCRIPTION
This is related to the issue with list of primitive variables. See jigna example here: https://github.com/enthought/jigna/blob/master/examples/list_of_primitives.py

Basically, since we create new objects every time a list is changed, angular doesn't know how to calculate what is selected. So you need to add some tracking expression against which it can compare to tell which element is selected.

Aside: According to angular docs, you shouldn't really use ng-options if the thing you're iterating over is a list of primitives. They suggest using something like this for that:

```
<select ng-model="vixen.camera">
<option ng-repeat="camera in vixen.available_cameras" value="{{camera}}">{{camera}}</option>
</select>
```
