### PR TITLE
Fix an issue with CSV export.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 before_script:
   - firefox --version
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
   - mkdir geckodriver
   - tar -xzf geckodriver*.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver

--- a/vixen/project.py
+++ b/vixen/project.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 
 if sys.version_info[0] > 2:
     unicode = str
+    string_types = (str,)
+else:
+    string_types = (basestring,)
 INT = fields.NUMERIC(numtype=int)
 FLOAT = fields.NUMERIC(numtype=float)
 
@@ -107,7 +110,7 @@ def _cleanup_query(q, tag_types):
 
 
 def _check_value(value, expr):
-    if isinstance(expr, (str, unicode)):
+    if isinstance(expr, string_types):
         return expr in value.lower()
     else:
         return expr == value
@@ -343,7 +346,7 @@ class Project(HasTraits):
         data_cols = set([x for x in cols if x in self._data])
 
         def _format(elem):
-            if isinstance(elem, str):
+            if isinstance(elem, string_types):
                 return '"%s"' % elem
             else:
                 return str(elem) if elem is not None else ""

--- a/vixen/tests/test_project.py
+++ b/vixen/tests/test_project.py
@@ -121,10 +121,14 @@ class TestProject(TestProjectBase):
 
     def test_export_to_csv(self):
         # Given
-        p = Project(name='test', path=self.root)
+        tags = [TagInfo(name='completed', type='bool'),
+                TagInfo(name='comment', type='string')]
+
+        p = Project(name='test', path=self.root, tags=tags)
         p.scan()
         m = p.get('root.txt')
         m.tags['completed'] = True
+        m.tags['comment'] = u'hello, world; foo'
         out_fname = tempfile.mktemp(dir=self.root, suffix='.csv')
 
         # When
@@ -134,25 +138,29 @@ class TestProject(TestProjectBase):
         reader = csv.reader(open(out_fname))
         cols = next(reader)
         expected = [
-            'completed', 'ctime', 'file_name', 'mtime', 'path', 'relpath',
-            'size', 'type'
+            'comment', 'completed', 'ctime', 'file_name', 'mtime', 'path',
+            'relpath', 'size', 'type'
         ]
         self.assertEqual(cols, expected)
         expected = {'hello.py': 'False', 'root.txt': 'True'}
         data = [next(reader), next(reader), next(reader), next(reader)]
-        data = sorted(data, key=lambda x: x[5])
+        data = sorted(data, key=lambda x: x[6])
         row = data[0]
-        self.assertEqual(basename(row[4]), 'hello.py')
-        self.assertEqual(row[0], 'False')
+        self.assertEqual(basename(row[5]), 'hello.py')
+        self.assertEqual(row[1], 'False')
+        self.assertEqual(row[0], '')
         row = data[1]
-        self.assertEqual(basename(row[4]), 'root.txt')
-        self.assertEqual(row[0], 'True')
+        self.assertEqual(basename(row[5]), 'root.txt')
+        self.assertEqual(row[1], 'True')
+        self.assertEqual(row[0], u'hello, world; foo')
         row = data[2]
-        self.assertTrue(basename(row[4]).startswith('sub'))
-        self.assertEqual(row[0], 'False')
+        self.assertTrue(basename(row[5]).startswith('sub'))
+        self.assertEqual(row[1], 'False')
+        self.assertEqual(row[0], '')
         row = data[3]
-        self.assertTrue(basename(row[4]).startswith('sub'))
-        self.assertEqual(row[0], 'False')
+        self.assertTrue(basename(row[5]).startswith('sub'))
+        self.assertEqual(row[1], 'False')
+        self.assertEqual(row[0], '')
 
     def test_refresh_updates_new_media(self):
         # Given


### PR DESCRIPTION
If the text is stored as unicode, it was not being exported correctly
when the text had commas.  The unicode fields were not being enclosed in
quotes resulting in incorrect CSV files.