### PR TITLE
Fix exporting and importing CSV with unicode.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mock
 pytest
 json_tricks>=3.0
 whoosh
+backports.csv


### PR DESCRIPTION
We now use `backports.csv` to do this correctly.  The application itself
can save tags as unicode but when exporting them we were not handling
unicode correctly.  So for now we export csv into UTF-8 encoded files
and import UTF-8 encoded files.