### PR TITLE
Check empty tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 before_script:
   - firefox --version
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz
   - mkdir geckodriver
   - tar -xzf geckodriver*.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver

--- a/vixen/integration_tests/test_ui.py
+++ b/vixen/integration_tests/test_ui.py
@@ -18,12 +18,6 @@ from vixen.vixen_ui import main
 from vixen.tests.test_directory import make_data
 
 
-def start_io_loop():
-    ioloop = IOLoop.instance()
-    ioloop.make_current()
-    ioloop.start()
-
-
 def stop_io_loop():
     IOLoop.instance().stop()
 
@@ -36,8 +30,8 @@ class TestUI(unittest.TestCase):
         make_data(cls.root)
         ui = make_ui()
         port = 9876
-        main(dev=True, port=port, test=True, **ui.get_context())
-        t = Thread(target=start_io_loop)
+        ioloop = main(dev=True, port=port, test=True, **ui.get_context())
+        t = Thread(target=ioloop.start)
         t.setDaemon(True)
         t.start()
 

--- a/vixen/vixen.py
+++ b/vixen/vixen.py
@@ -138,12 +138,13 @@ class ProjectEditor(HasTraits):
         return True
 
     def add_tag(self, name):
-        names = [x.strip() for x in name.split(',')]
-        if self._check_tags(names):
-            logger.info('Added tags: %s', name)
-            tags = [TagInfo(name=x, type="string") for x in names]
-            self.tags.extend(tags)
-            self.tag_name = ''
+        if len(name) > 0:
+            names = [x.strip() for x in name.split(',')]
+            if self._check_tags(names):
+                logger.info('Added tags: %s', name)
+                tags = [TagInfo(name=x, type="string") for x in names]
+                self.tags.extend(tags)
+                self.tag_name = ''
 
     def remove_tag(self, index):
         logger.info('Removed tag: %s', self.tags[index].name)

--- a/vixen/vixen_ui.py
+++ b/vixen/vixen_ui.py
@@ -58,7 +58,7 @@ def main(dev=False, port=None, test=False, **context):
     html = get_html(html_file)
     template = VueTemplate(html=html, base_url=base_url, async=async)
     silence_tornado_access_log()
-    ioloop = IOLoop.instance()
+    ioloop = IOLoop.current()
     if port is None:
         if dev:
             port = 8000
@@ -81,3 +81,5 @@ def main(dev=False, port=None, test=False, **context):
     if not test:
         # When running tests, don't start the ioloop.
         ioloop.start()
+    else:
+        return ioloop


### PR DESCRIPTION
- Ignore empty tags.
- Also fix issues with integration tests and tornado 5.x  This does need a rethink as I suspect the current approach is just a dirty hack.  Works for now though.