### PR TITLE
Add a button to shuffle files in a page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 build/
 dist/
 *.egg-info/
+
+# Vim swap files
+*.swp
+
+# pytest cache
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ dist/
 *.swp
 
 # pytest cache
-.cache
+.*cache
+
+*.log

--- a/vixen/html/vixen_ui.html
+++ b/vixen/html/vixen_ui.html
@@ -232,6 +232,9 @@
       <button v-on:click="viewer.go_to_parent()" id="go-to-parent">
         Go to Parent
       </button>
+      <button v-on:click="viewer.pager.shuffle_page()" id="shuffle-page">
+        Shuffle Page
+      </button>
       <div style="height:100px; width: 300px;"
            class="resizable directory-browser">
         <div v-for="path in pager.data | limitBy pager.limit pager.start">

--- a/vixen/tests/test_pager.py
+++ b/vixen/tests/test_pager.py
@@ -105,6 +105,27 @@ class TestPager(unittest.TestCase):
         self.assertEqual(p.page, 3)
         self.assertEqual(p.selected, 2)
 
+    def test_shuffle_page(self):
+        """Check if shuffling a page works."""
+        p = Pager(limit=5)
+
+        # When
+        p.data = list(range(10))
+        p.shuffle_page()
+
+        # Then, first five elements should be shuffled, rest same
+        self.assertListEqual(p.data[5:], list(range(5, 10)))
+        self.assertNotEqual(p.data[:5], list(range(5)))
+
+        # When
+        p.data = list(range(10))
+        p.next_page()
+        p.shuffle_page()
+
+        # Then, first five elements should be same, rest different
+        self.assertNotEqual(p.data[5:], list(range(5, 10)))
+        self.assertListEqual(p.data[:5], list(range(5)))
+
     def test_prev_page(self):
         # Given
         p = Pager(limit=2)

--- a/vixen/vixen.py
+++ b/vixen/vixen.py
@@ -6,6 +6,7 @@ import logging
 from logging import Handler
 from os.path import dirname, exists, join, isdir
 import os
+from random import shuffle
 import subprocess
 import sys
 from traits.api import (Any, Bool, DelegatesTo, Dict, Enum, HasTraits,
@@ -154,7 +155,7 @@ class ProjectEditor(HasTraits):
         if index != 0:
             tags = self.tags
             logger.info('Moving up tag: %s', tags[index].name)
-            tags[index - 1:index + 1] = tags[index], tags[index-1]
+            tags[index - 1:index + 1] = tags[index], tags[index - 1]
 
     def move_tag_down(self, index):
         tags = self.tags
@@ -298,6 +299,13 @@ class Pager(HasTraits):
     _page = Int
     _index = Int
 
+    def shuffle_page(self):
+        """Shuffle the current page."""
+        pages = self.view.copy()
+        shuffle(pages)
+        p = self.page - 1
+        self.data[p * self.limit:(p + 1) * self.limit] = pages
+
     def select(self, relindex=None):
         if relindex is None:
             index = self.index
@@ -345,7 +353,7 @@ class Pager(HasTraits):
     def _get_view(self):
         p = self.page - 1
         limit = self.limit
-        return self.data[p*limit:(p+1)*limit]
+        return self.data[p * limit:(p + 1) * limit]
 
     def _get_index(self):
         return self._index

--- a/vixen/vixen.py
+++ b/vixen/vixen.py
@@ -301,7 +301,7 @@ class Pager(HasTraits):
 
     def shuffle_page(self):
         """Shuffle the current page."""
-        pages = self.view.copy()
+        pages = self.view[:]
         shuffle(pages)
         p = self.page - 1
         self.data[p * self.limit:(p + 1) * self.limit] = pages


### PR DESCRIPTION
When viewing a large directory of files, especially if they relate to some computer vision problem, the images often need to be eyeballed randomly. This PR adds a button to shuffle files within a page.

![out](https://user-images.githubusercontent.com/1250388/43000990-39eda0c6-8c41-11e8-8084-79d1b0243590.gif)
