### PR TITLE
Improve CSS for scrolling behavior of side panel.

### DIFF
--- a/vixen/html/css/style.css
+++ b/vixen/html/css/style.css
@@ -25,7 +25,11 @@ div, article, section {
 .half {
   width: 50%; }
 .third {
-  width: 33.333%; }
+    width: 33.333%;
+    height: 80%;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
 .sans-third {
   width: 66.66%; }
 .quarter {


### PR DESCRIPTION
When there are many tags which are larger than a full page, the
scrolling would scroll the entire page -- including the view on the
right side which was annoying.  This minor CSS change scrolls the left
panel independently of the right side.